### PR TITLE
Correction de typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ N'hésitez pas à lire [le guide des contributeurs](CONTRIBUTING.md).
 * [Supprimer les développements spécifiques non utilisés](practices/05_supprimer-les-developpements-specifiques-non-utilises.md)
 * [Reporter les tâches qui peuvent l'être pour lisser la charge](practices/06_lisser-la-charge.md)
 * [Minimiser les ressources nécessaires au projet](practices/07_minimiser-les-ressources-necessaires-au-projet.md)
-* [Supprimer les containers qui ne sont plus utiles](practices/08_supprimer-les-conteneurs-qui-ne-sont-plus-utiles.md)
+* [Supprimer les conteneurs qui ne sont plus utiles](practices/08_supprimer-les-conteneurs-qui-ne-sont-plus-utiles.md)
 * [Désactiver l'auto-start et activer l'auto-stop](practices/09_desactiver-l_autostart-et-activer-l_auto-stop.md)
 * [Limiter la fréquence de lancement des builds](practices/10_limiter-la-frequence-de-lancement-des-builds.md)
 * [Répartir les builds dans le temps](practices/11_repartir-les-builds-dans-le-temps.md)

--- a/practices/08_supprimer-les-conteneurs-qui-ne-sont-plus-utiles.md
+++ b/practices/08_supprimer-les-conteneurs-qui-ne-sont-plus-utiles.md
@@ -1,4 +1,4 @@
-# Supprimer les containers qui ne sont plus utiles
+# Supprimer les conteneurs qui ne sont plus utiles
 
 
 ## Catégories

--- a/practices/09_desactiver-l_autostart-et-activer-l_auto-stop.md
+++ b/practices/09_desactiver-l_autostart-et-activer-l_auto-stop.md
@@ -34,9 +34,9 @@ Il est aussi important de limiter le plus possible le démarrage automatique des
 
 ## Exemple
 
-J’ai un container Docker actif qui ne m’est pas utile dans l’immédiat. Il utilise des ressources inutilement. S’il 
+J’ai un conteneur Docker actif qui ne m’est pas utile dans l’immédiat. Il utilise des ressources inutilement. S’il 
 s’éteignait automatiquement, il ne consommerait pas de ressources autres que de l’espace disque. Cette stratégie 
-appliquée à l’ensemble des containers Docker permet de downsizer l’infrastructure matérielle dédiée.
+appliquée à l’ensemble des conteneurs Docker permet de downsizer l’infrastructure matérielle dédiée.
 
 
 ### Principe de validation

--- a/practices/10_limiter-la-frequence-de-lancement-des-builds.md
+++ b/practices/10_limiter-la-frequence-de-lancement-des-builds.md
@@ -48,7 +48,7 @@ La stratégie suivante peut par exemple être utilisée :
 * Pipeline « Next Major », 1 fois par mois.
 * Pipeline « All » (simulant toutes les extensions actuelles de l’env. de prod) 1 fois toutes les 2 semaines.
 * Next Major, Next Minor et All ne sont pas à initialiser au début d’un projet OnPrem.
-* 
+
 Ces règles peuvent être flexibles en fonction du contexte projet (Next Major très proche, test de nouvelles versions, …).
 Cependant, ces cas doivent rester exceptionnels.
 


### PR DESCRIPTION
Petites corrections de typos, notamment un usage inconsistant de `container` et `conteneur`